### PR TITLE
ci: build wheels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,9 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pypa/cibuildwheel@v2.14
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
+      - uses: pypa/cibuildwheel@v2.16
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,10 @@ name: CD
 
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
   release:
     types:
       - published

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,69 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - name: Check metadata
+        run: pipx run twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Python 3.12 on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pypa/cibuildwheel@v2.14
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
+
+  upload_all:
+    name: Upload if release
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/interpreters-3-12
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: List all files
+        run: ls -lh dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' && github.event.action == 'published'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,17 @@ ignore = [
 ]
 
 [tool.cibuildwheel]
+# Avoid PyPy
 skip = ["pp*"]
+
 # Trigger an install of the package, but run nothing of note
 test-command = "echo Wheel installed"
+
 # Don't show a warning about not being able to test the ARM part of a wheel
 test-skip = ["*universal2:arm64"]
 
+# Avoid 32-bit Windows
+windows.archs = ["auto64"]
+
 # Force universal2 wheels on macOS
-[tool.cibuildwheel.macos]
-archs = ["universal2"]
+macos.archs = ["universal2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Use this module to try out multiple interpreters and a per-interpreter GIL in Python 3.12.  Do not use this for anything important."
 readme = "README.md"
-requires-python = "=3.12"
+requires-python = ">=3.12,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",
@@ -71,3 +71,14 @@ ignore = [
   "S101",  # "assert" is OK
   "E702",  # Statements on one line OK
 ]
+
+[tool.cibuildwheel]
+skip = ["pp*"]
+# Trigger an install of the package, but run nothing of note
+test-command = "echo Wheel installed"
+# Don't show a warning about not being able to test the ARM part of a wheel
+test-skip = ["*universal2:arm64"]
+
+# Force universal2 wheels on macOS
+[tool.cibuildwheel.macos]
+archs = ["universal2"]


### PR DESCRIPTION
Needs #3. Closes #1. Assumes this repo gets set up with PyPI trusted publisher deployment.
